### PR TITLE
Update to load API keys from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+GEMINI_API=your_api_key
+GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/tts-service-account.json
+REACT_APP_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ It has a React frontend (in the `frontend` folder) and a simple FastAPI backend.
 
 ## Environment Variables
 
-Set the following variables to enable external APIs:
+Copy `.env.example` to `.env` in the project root and fill in your own values.
+These variables enable external APIs:
 
 ```
 GEMINI_API=your_api_key
 GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/tts-service-account.json
+REACT_APP_API_URL=http://localhost:8000
 ```
 
 ## Google cloud tts

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,19 @@
+"""FastAPI backend for the English Communication App."""
+
 from fastapi import FastAPI
 from pydantic import BaseModel
+from dotenv import load_dotenv
+import os
+
+# Load environment variables from the `.env` file located at the project root.
+# This allows developers to keep API keys outside of the source code.
+load_dotenv()
+
+# API keys read from the environment
+GEMINI_API_KEY = os.getenv("GEMINI_API", "")
+GOOGLE_APPLICATION_CREDENTIALS = os.getenv(
+    "GOOGLE_APPLICATION_CREDENTIALS", ""
+)
 
 app = FastAPI()
 
@@ -20,6 +34,9 @@ class Response(BaseModel):
 async def respond(req: Request):
     """Echo the text received from the user."""
 
-    # In a real app, integrate with GEMINI API or other services here
+    # In a real app, integrate with GEMINI API or other services here.
+    # Example:
+    # if GEMINI_API_KEY:
+    #     call_external_api(req.text, GEMINI_API_KEY)
     reply_text = f"You said: {req.text}"
     return Response(reply=reply_text)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,3 +5,4 @@ version = "0.1.0"
 [project.dependencies]
 fastapi = "*"
 uvicorn = "*"
+python-dotenv = "*"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+python-dotenv

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,10 @@ function App() {
   // List of chat messages to display
   const [messages, setMessages] = useState([]);
 
+  // Base URL for the backend. React reads environment variables starting with
+  // REACT_APP_. We provide a fallback so the app works out of the box.
+  const API_URL = process.env.REACT_APP_API_URL || '';
+
   // Send the message to the backend and handle the response
   const sendMessage = async () => {
     if (!input) return;
@@ -14,7 +18,7 @@ function App() {
     setMessages((msgs) => [...msgs, userMsg]);
     setInput('');
     try {
-      const res = await fetch('/api/respond', {
+      const res = await fetch(`${API_URL}/api/respond`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text: input }),


### PR DESCRIPTION
## Summary
- read API keys using `python-dotenv`
- expose backend URL with `REACT_APP_API_URL`
- document environment variables and add `.env.example`

## Testing
- `black backend --line-length 79`
- `CI=true npm test --silent -- --watchAll=false`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684cdc1a4b7c83329a7c315d75fb27ac